### PR TITLE
A number of improvements to ForwardDiff benchmarks

### DIFF
--- a/src/Benchmarks.jl
+++ b/src/Benchmarks.jl
@@ -72,7 +72,7 @@ export rosenbrock_jacobian_benchmarks
 const R100_R100_jacobian_benchmarks = (fd_R¹⁰⁰R¹⁰⁰, forward_diff_R¹⁰⁰R¹⁰⁰, reverse_diff_R¹⁰⁰R¹⁰⁰, enzyme_R¹⁰⁰R¹⁰⁰)
 export R100_R100_jacobian_benchmarks
 
-const SH_Functions_benchmarks = (fd_SHFunctions, forward_diff_SHFunctions, reverse_diff_SHFunctions, enzyme_SHFunctions)
+const SH_Functions_benchmarks = (fd_SHFunctions, forward_diff_SHFunctions, #=reverse_diff_SHFunctions,=# enzyme_SHFunctions)
 export SH_Functions_benchmarks
 
 const ODE_benchmarks = (fd_ODE_sparse, fd_ODE, forward_diff_ODE, reverse_diff_ODE, enzyme_ODE)

--- a/src/ForwardDiffBenchmarks.jl
+++ b/src/ForwardDiffBenchmarks.jl
@@ -7,7 +7,7 @@ function forward_diff_rosenbrock_gradient(nterms)
     fastest = typemax(Float64)
     local best_trial
 
-    for chunk_size in 1:3:min(nterms, 10)
+    for chunk_size in (1, 4:4:min(nterms, 10)...)
         cfg = ForwardDiff.GradientConfig(rosenbrock, x, ForwardDiff.Chunk{chunk_size}())
         trial = @benchmark ForwardDiff.gradient!($out, $rosenbrock, $x, $cfg)
         if minimum(trial).time < fastest
@@ -32,7 +32,7 @@ function forward_diff_R¹⁰⁰R¹⁰⁰(nsize)
     fastest = typemax(Float64)
     local best_trial
 
-    for chunk_size in 1:3:min(nsize, 10)
+    for chunk_size in 1:3:min(nsize, 20)
         cfg = ForwardDiff.JacobianConfig(f, inputs, ForwardDiff.Chunk{chunk_size}())
         trial = @benchmark ForwardDiff.jacobian!($results, $f, $inputs, $cfg)
         if minimum(trial).time < fastest
@@ -75,7 +75,7 @@ function forward_diff_SHFunctions(nterms)
     local best_trial
     sh_wrapper(x) = SHFunctions(nterms, x[1], x[2], x[3])
 
-    for chunk_size in 1:1:3
+    for chunk_size in 1:3
         cfg = ForwardDiff.JacobianConfig(sh_wrapper, x, ForwardDiff.Chunk{chunk_size}())
         trial = @benchmark ForwardDiff.jacobian($sh_wrapper, $x, $cfg)
         if minimum(trial).time < fastest
@@ -88,21 +88,26 @@ end
 export forward_diff_SHFunctions
 
 function forward_diff_ODE()
-    swap_args!(y, x) = ODE.f(x, y, nothing, nothing)
+    def_args!(dy, y) = ODE.f(dy, y, nothing, nothing)
 
-    y = rand(20)
+    y = copy(ODE.u0)
     dy = Vector{Float64}(undef, 20)
+    fastest = typemax(Float64)
+    local best_trial
+    J_forward = similar(y, 20, 20)
+    J_hand = similar(y, 20, 20)
 
     for chunk_size in 1:3:20
-        cfg = ForwardDiff.JacobianConfig(swap_args!, y, dy, ForwardDiff.Chunk{chunk_size}())
-        trial = @benchmark ForwardDiff.jacobian($swap_args!, $y, $cfg)
+        cfg = ForwardDiff.JacobianConfig(def_args!, dy, y, ForwardDiff.Chunk{chunk_size}())
+        trial = @benchmark ForwardDiff.jacobian!($J_forward, $def_args!, $dy, $y, $cfg)
         if minimum(trial).time < fastest
             best_trial = trial
             fastest = minimum(trial).time
         end
     end
+    ODE.fjac(J_hand, y, nothing, nothing)
+    J_hand ≈ J_forward || error("Inaccurate Jacobian")
 
     return best_trial
 end
 export forward_diff_ODE
-

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -184,15 +184,15 @@ function fjac(J, y, p, t)
     return nothing
 end
 
-end #module
+const u0 = zeros(20)
+u0[2] = 0.2
+u0[4] = 0.04
+u0[7] = 0.1
+u0[8] = 0.3
+u0[9] = 0.01
+u0[17] = 0.007
 
-# u0 = zeros(20)
-# u0[2] = 0.2
-# u0[4] = 0.04
-# u0[7] = 0.1
-# u0[8] = 0.3
-# u0[9] = 0.01
-# u0[17] = 0.007
+end #module
 
 # temp_jac(J)
 # prob = ODEProblem(ODEFunction{true,SciMLBase.FullSpecialize}(f, jac=fjac), u0, (0.0, 60.0))


### PR DESCRIPTION
Change the chunk size to be multiples of 4, and use deterministic
initial condition, and add a sanity check for the Jacobian when analytic
solution exists.
